### PR TITLE
Enhance default SSL config in site.erb

### DIFF
--- a/nginx/templates/default/site.erb
+++ b/nginx/templates/default/site.erb
@@ -40,6 +40,13 @@ server {
   ssl_client_certificate <%= node[:nginx][:dir] %>/ssl/<%= @application[:domains].first %>.ca;
   <% end -%>
 
+  # Following lines added by Kiere El-Shafie on 2016-11-14
+  # See: https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+
   location / {
     root   <%= @application[:absolute_document_root] %>;
     index  index.html index.htm index.php;


### PR DESCRIPTION
The default nginx cookbook does not have these enabled so our SSL grade on ssllabs.com is capped to a "C" (we want an A+).